### PR TITLE
Optimize and enhance chess engine repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,36 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+.venv/
+env/
+venv/
+ENV/
+
+# Jupyter
+.ipynb_checkpoints/
+
+# Data/weights
+checkpoint.pt
+*.h5
+*.pack
+*.tar.bz2
+Data/
+
+# Editor/OS
+.DS_Store
+*.swp
+*.swo
+.idea/
+.vscode/
+
+# Artifacts
+*.png
+*.svg
+*.log
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: format lint test play
+
+format:
+	python -m py_compile $(shell git ls-files '*.py')
+
+lint:
+	python -m py_compile $(shell git ls-files '*.py')
+
+test:
+	pytest -q
+
+play:
+	python play.py --white model --black search --max-moves 20 --depth 3 --time 0.5
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Chess Engine With Neural Networks (1300 ELO)
-## I am expanding from scratch with neural networks. WIP stay tuned
+# Chess Engine with Neural Networks and Search
+
+Modernized, testable chess engine repo combining a learnable board evaluator with a classic alpha-beta searcher and a clean gameplay harness.
 
 ## Knowledge distillation from Leela Chess Zero (captureTheQueen model)
 
@@ -32,19 +33,40 @@ The model itself is implemented in
 * py_layers.py
 * pt_losses.py
 
-## Playing
+## Quick Start (Inference & Play)
 
-Training can be done without understanding chess, but in order to apply the trained model two things need to be done:
-* The policy output tensor needs to be mapped to moves (see policy_index.py and lc0_az_policy_map.py)
-* The chess board state needs to be converted into LC0's planes format.
+1. Create and activate a virtual environment, then install deps:
 
-./captureTheQueen/model.py has the model collected into a single file that can play in the tournament (and ./captureTheQueen/model_config.yaml).
+```
+python3 -m venv .venv && source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+2. Validate your submission interface quickly:
+
+```
+python pre_submission_val.py
+```
+
+3. Play a demo self-play game (no rendering):
+
+```
+python play.py --white model --black search --max-moves 40
+```
+
+Options:
+- `--white/--black`: one of `random`, `model`, `search`, `search+model` (search guided by the model evaluator)
+- `--render /path/to/out.png`: save a nice board image after each move (requires cairosvg, matplotlib, Pillow)
+- `--depth`: search depth for search-based agents
+
+Stockfish detection is automatic. To override, set `STOCKFISH_PATH` environment variable.
 
 
 
 
 
-# Original hackathon documentation
+## Original hackathon documentation
 
 
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ pip install -r requirements.txt
 python pre_submission_val.py
 ```
 
-3. Play a demo self-play game (no rendering):
+3. Play a demo self-play game (model vs model, no rendering):
 
 ```
-python play.py --white model --black search --max-moves 40
+python play.py --white model --black model --max-moves 40
 ```
 
 Options:
@@ -60,7 +60,7 @@ Options:
 - `--render /path/to/out.png`: save a nice board image after each move (requires cairosvg, matplotlib, Pillow)
 - `--depth`: search depth for search-based agents
 
-Stockfish detection is automatic. To override, set `STOCKFISH_PATH` environment variable.
+Stockfish is not used for playing the model. It is only used if you explicitly choose a search-based agent, or for optional position evaluation in the visuals. To override its path, set `STOCKFISH_PATH` environment variable.
 
 
 

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,18 @@
+from .search import (
+    SearchConfig,
+    Evaluator,
+    MaterialEvaluator,
+    ModelEvaluator,
+    AlphaBetaSearcher,
+    SearchAgent,
+)
+
+__all__ = [
+    'SearchConfig',
+    'Evaluator',
+    'MaterialEvaluator',
+    'ModelEvaluator',
+    'AlphaBetaSearcher',
+    'SearchAgent',
+]
+

--- a/engine/search.py
+++ b/engine/search.py
@@ -1,0 +1,233 @@
+import io
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional, Tuple, Dict, List
+
+import chess
+import chess.pgn
+
+
+def _default_move_order(board: chess.Board, moves: List[chess.Move]) -> List[chess.Move]:
+    def score_move(m: chess.Move) -> int:
+        score = 0
+        if board.is_capture(m):
+            score += 1000
+        if board.is_en_passant(m):
+            score += 500
+        if board.gives_check(m):
+            score += 300
+        if m.promotion:
+            score += 800 + m.promotion
+        return score
+
+    return sorted(moves, key=score_move, reverse=True)
+
+
+@dataclass
+class SearchConfig:
+    max_depth: int = 3
+    time_limit_sec: float = 1.0
+    use_iterative_deepening: bool = True
+    quiescence_depth: int = 0
+    transposition_table: bool = True
+    move_ordering: bool = True
+
+
+class Evaluator:
+    def evaluate(self, board: chess.Board) -> float:
+        raise NotImplementedError
+
+
+class MaterialEvaluator(Evaluator):
+    PIECE_VALUES = {
+        chess.PAWN: 100,
+        chess.KNIGHT: 320,
+        chess.BISHOP: 330,
+        chess.ROOK: 500,
+        chess.QUEEN: 900,
+        chess.KING: 0,
+    }
+
+    def evaluate(self, board: chess.Board) -> float:
+        # Positive means good for side to move.
+        score = 0
+        for piece_type, value in self.PIECE_VALUES.items():
+            score += value * (len(board.pieces(piece_type, board.turn)) - len(board.pieces(piece_type, not board.turn)))
+        return float(score)
+
+
+class ModelEvaluator(Evaluator):
+    def __init__(self, model):
+        self.model = model
+        try:
+            self.model.eval()
+        except Exception:
+            pass
+
+    def evaluate(self, board: chess.Board) -> float:
+        # Expect model to return score from the perspective of the side to move.
+        # Prefer a direct board evaluation method if present.
+        if hasattr(self.model, "evaluate_board"):
+            value = self.model.evaluate_board(board)
+            return float(value)
+
+        # Fallback: reconstruct a PGN and score a null move equivalent by averaging moves.
+        # Better: directly call forward using model.encode_board.
+        try:
+            from model import encode_board  # type: ignore
+            import torch
+
+            with torch.no_grad():
+                board_tensor = torch.tensor(encode_board(board)).unsqueeze(0)
+                value = self.model(board_tensor).item()
+                return float(value)
+        except Exception:
+            # Last resort: simple material
+            return MaterialEvaluator().evaluate(board)
+
+
+class TranspositionTable:
+    def __init__(self) -> None:
+        self._table: Dict[str, Tuple[int, float, Optional[chess.Move]]] = {}
+
+    def probe(self, board: chess.Board, depth: int) -> Optional[Tuple[int, float, Optional[chess.Move]]]:
+        key = board.board_fen() + (" w" if board.turn else " b")
+        return self._table.get(key)
+
+    def store(self, board: chess.Board, depth: int, value: float, move: Optional[chess.Move]) -> None:
+        key = board.board_fen() + (" w" if board.turn else " b")
+        self._table[key] = (depth, value, move)
+
+
+class AlphaBetaSearcher:
+    def __init__(self, evaluator: Evaluator, config: Optional[SearchConfig] = None) -> None:
+        self.evaluator = evaluator
+        self.config = config or SearchConfig()
+        self.tt = TranspositionTable() if self.config.transposition_table else None
+        self.start_time: float = 0.0
+
+    def _time_up(self) -> bool:
+        if self.config.time_limit_sec <= 0:
+            return False
+        return (time.perf_counter() - self.start_time) >= self.config.time_limit_sec
+
+    def search(self, board: chess.Board) -> chess.Move:
+        self.start_time = time.perf_counter()
+        best_move: Optional[chess.Move] = None
+        max_depth = self.config.max_depth
+
+        if self.config.use_iterative_deepening:
+            for depth in range(1, max_depth + 1):
+                if self._time_up():
+                    break
+                value, move = self._alphabeta_root(board, depth)
+                if move is not None:
+                    best_move = move
+        else:
+            _, best_move = self._alphabeta_root(board, max_depth)
+
+        # Fallback if no move found (shouldn't happen)
+        return best_move or next(iter(board.legal_moves))
+
+    def _alphabeta_root(self, board: chess.Board, depth: int) -> Tuple[float, Optional[chess.Move]]:
+        alpha = float("-inf")
+        beta = float("inf")
+        best_value = float("-inf")
+        best_move: Optional[chess.Move] = None
+
+        legal_moves = list(board.legal_moves)
+        if self.config.move_ordering:
+            legal_moves = _default_move_order(board, legal_moves)
+
+        for move in legal_moves:
+            if self._time_up():
+                break
+            board.push(move)
+            value = -self._alphabeta(board, depth - 1, -beta, -alpha)
+            board.pop()
+            if value > best_value:
+                best_value = value
+                best_move = move
+            if value > alpha:
+                alpha = value
+        return best_value, best_move
+
+    def _alphabeta(self, board: chess.Board, depth: int, alpha: float, beta: float) -> float:
+        if self._time_up():
+            return self.evaluator.evaluate(board)
+
+        if depth <= 0:
+            return self._quiescence(board, alpha, beta, self.config.quiescence_depth)
+
+        if self.tt is not None:
+            hit = self.tt.probe(board, depth)
+            if hit is not None:
+                stored_depth, stored_value, _ = hit
+                if stored_depth >= depth:
+                    return stored_value
+
+        legal_moves = list(board.legal_moves)
+        if not legal_moves:
+            if board.is_checkmate():
+                # Large negative for side to move in checkmate
+                return -float(1e6)
+            return 0.0
+
+        if self.config.move_ordering:
+            legal_moves = _default_move_order(board, legal_moves)
+
+        value = float("-inf")
+        for move in legal_moves:
+            board.push(move)
+            score = -self._alphabeta(board, depth - 1, -beta, -alpha)
+            board.pop()
+            if score > value:
+                value = score
+            if value > alpha:
+                alpha = value
+            if alpha >= beta:
+                break
+
+        if self.tt is not None:
+            self.tt.store(board, depth, value, None)
+        return value
+
+    def _quiescence(self, board: chess.Board, alpha: float, beta: float, q_depth: int) -> float:
+        stand_pat = self.evaluator.evaluate(board)
+        if stand_pat >= beta:
+            return beta
+        if alpha < stand_pat:
+            alpha = stand_pat
+        if q_depth <= 0:
+            return stand_pat
+
+        capture_moves = [m for m in board.legal_moves if board.is_capture(m)]
+        if self.config.move_ordering:
+            capture_moves = _default_move_order(board, capture_moves)
+
+        for move in capture_moves:
+            board.push(move)
+            score = -self._quiescence(board, -beta, -alpha, q_depth - 1)
+            board.pop()
+            if score >= beta:
+                return beta
+            if score > alpha:
+                alpha = score
+        return alpha
+
+
+class SearchAgent:
+    def __init__(self, evaluator: Optional[Evaluator] = None, config: Optional[SearchConfig] = None):
+        self.searcher = AlphaBetaSearcher(evaluator or MaterialEvaluator(), config)
+
+    def select_move(self, pgn: str, legal_move_sans: List[str]) -> str:
+        # Reconstruct board from PGN string
+        game = chess.pgn.read_game(io.StringIO(pgn))
+        board = chess.Board()
+        if game is not None:
+            for past_move in list(game.mainline_moves()):
+                board.push(past_move)
+
+        best_move = self.searcher.search(board)
+        return board.san(best_move)
+

--- a/play.py
+++ b/play.py
@@ -43,7 +43,7 @@ def make_agent(kind: str, model: Model, depth: int, time_sec: float) -> Agent:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Play a quick chess game between agents.")
     parser.add_argument('--white', default='model', help='random | model | search | search+model')
-    parser.add_argument('--black', default='search', help='random | model | search | search+model')
+    parser.add_argument('--black', default='model', help='random | model | search | search+model')
     parser.add_argument('--max-moves', type=int, default=40)
     parser.add_argument('--depth', type=int, default=3)
     parser.add_argument('--time', type=float, default=1.0, help='Time limit per search in seconds')

--- a/play.py
+++ b/play.py
@@ -1,0 +1,75 @@
+import argparse
+import io
+import os
+import chess
+import chess.pgn
+from typing import Dict
+
+from chess_gameplay import Agent, play_game
+from model import Model
+import yaml
+
+from engine.search import SearchAgent, SearchConfig, ModelEvaluator, MaterialEvaluator
+
+
+def make_agent(kind: str, model: Model, depth: int, time_sec: float) -> Agent:
+    kind = kind.lower()
+    if kind == 'random':
+        return Agent(model=None)
+    if kind == 'model':
+        return Agent(model=model)
+    if kind == 'search':
+        search_agent = SearchAgent(evaluator=MaterialEvaluator(), config=SearchConfig(max_depth=depth, time_limit_sec=time_sec))
+        # Wrap to conform to Agent API
+        class Wrapper:
+            def score(self, pgn: str, move: str) -> float:
+                # Not used by Agent when select_move overridden, but kept for compatibility
+                return 0.0
+            def select_move(self, pgn, legal_moves):
+                return search_agent.select_move(pgn, legal_moves)
+        return Agent(model=Wrapper())
+    if kind in ('search+model', 'model+search'):
+        evaluator = ModelEvaluator(model)
+        search_agent = SearchAgent(evaluator=evaluator, config=SearchConfig(max_depth=depth, time_limit_sec=time_sec))
+        class Wrapper:
+            def score(self, pgn: str, move: str) -> float:
+                return 0.0
+            def select_move(self, pgn, legal_moves):
+                return search_agent.select_move(pgn, legal_moves)
+        return Agent(model=Wrapper())
+    raise ValueError(f"Unknown agent kind: {kind}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Play a quick chess game between agents.")
+    parser.add_argument('--white', default='model', help='random | model | search | search+model')
+    parser.add_argument('--black', default='search', help='random | model | search | search+model')
+    parser.add_argument('--max-moves', type=int, default=40)
+    parser.add_argument('--depth', type=int, default=3)
+    parser.add_argument('--time', type=float, default=1.0, help='Time limit per search in seconds')
+    parser.add_argument('--render', type=str, default=None, help='Path to save board images per move')
+    args = parser.parse_args()
+
+    # Load model config and checkpoint if available
+    model_config = {}
+    if os.path.exists('model_config.yaml'):
+        model_config = yaml.safe_load(open('model_config.yaml'))
+    model = Model(**model_config) if hasattr(Model, '__call__') else None
+    if model and os.path.exists('checkpoint.pt'):
+        import torch
+        ckpt = torch.load('checkpoint.pt', map_location='cpu')
+        state_dict = ckpt['model'] if isinstance(ckpt, dict) and 'model' in ckpt else ckpt
+        try:
+            model.load_state_dict(state_dict)
+        except Exception:
+            pass
+
+    agents: Dict[str, Agent] = {
+        'white': make_agent(args.white, model, args.depth, args.time),
+        'black': make_agent(args.black, model, args.depth, args.time),
+    }
+    teams = {'white': f'White({args.white})', 'black': f'Black({args.black})'}
+
+    result = play_game(agents=agents, teams=teams, max_moves=args.max_moves, min_seconds_per_move=0.0, verbose=True, poseval=False, image_path=args.render)
+    print({k: v['points'] for k, v in result.items() if k in ('white','black')})
+

--- a/requirements.inference.txt
+++ b/requirements.inference.txt
@@ -1,0 +1,11 @@
+# Minimal dependencies for inference and CLI gameplay
+torch==2.3.1
+chess==1.10.0
+pyyaml==6.0.1
+numpy==1.26.4
+
+# Optional for rendering nice boards
+# matplotlib==3.9.0
+# cairosvg==2.7.1
+# Pillow==10.4.0
+

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+import chess
+
+from model import Model
+from chess_gameplay import Agent, play_game
+
+
+def test_model_instantiates():
+    m = Model()
+    assert hasattr(m, 'score')
+
+
+def test_play_quick_game():
+    m0 = Model()
+    a0, a1 = Agent(m0), Agent(m0)
+    result = play_game(
+        agents={'white': a0, 'black': a1},
+        teams={'white': 'W', 'black': 'B'},
+        max_moves=4,
+        min_seconds_per_move=0.0,
+        verbose=False,
+        poseval=False,
+        image_path=None,
+    )
+    assert 'white' in result and 'black' in result
+

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -8,4 +8,29 @@ PIECE_CHARS = "♔♕♖♗♘♙⭘♟♞♝♜♛♚"
 PGN_CHARS = " #+-./0123456789:=BKLNOQRabcdefghx{}*"
 
 # Path to stockfish binary used for engine
-STOCKFISH_PATH = "/root/chess-hackathon-4/utils/stockfish"
+import os
+import shutil
+
+def _detect_stockfish_path() -> str:
+    candidates = []
+    # Local utils directory
+    here = os.path.dirname(__file__)
+    candidates.append(os.path.join(here, 'stockfish'))
+    # Repo root utils directory (in case of different invocation path)
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    candidates.append(os.path.join(repo_root, 'utils', 'stockfish'))
+    # Environment override
+    env_path = os.environ.get('STOCKFISH_PATH')
+    if env_path:
+        candidates.insert(0, env_path)
+    # System PATH
+    which = shutil.which('stockfish')
+    if which:
+        candidates.append(which)
+    for path in candidates:
+        if path and os.path.exists(path):
+            return path
+    # Fallback to name hoping it is on PATH
+    return 'stockfish'
+
+STOCKFISH_PATH = _detect_stockfish_path()


### PR DESCRIPTION
Add a robust alpha-beta search engine, enhance the model for direct board evaluation and vectorized move scoring, and introduce a CLI for playing and testing, significantly improving the engine's capabilities and usability.

The original repository lacked a dedicated search component, making the engine rely solely on the neural network for move selection. This PR integrates a classic search algorithm (alpha-beta with enhancements) and allows the neural network to act as a board evaluator within that search, creating a more powerful and flexible hybrid engine. The CLI provides an immediate way to experiment with these new capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0d2f855-9a34-42c3-a3bf-62ba8905823c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f0d2f855-9a34-42c3-a3bf-62ba8905823c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a hybrid chess engine: an alpha-beta searcher that can use the neural model as a board evaluator, plus a simple CLI to play and test. This improves move quality, speeds up scoring, and makes the repo easier to use.

- **New Features**
  - New engine module with alpha-beta search (iterative deepening, transposition table, move ordering) and pluggable evaluators (material, model-backed).
  - Model now supports evaluate_board and vectorized score_moves for fast, batch move scoring.
  - CLI (play.py) to pit random/model/search/search+model agents with depth/time controls and optional rendering.
  - Quick-start docs, Makefile targets (format/lint/test/play), minimal inference requirements, and smoke tests.

- **Bug Fixes**
  - Positional encoding fixed to work with batch-first tensors.
  - Safer model scoring: handles illegal SAN and empty games without crashing.
  - Rendering imports are lazy with a clear error if deps are missing.
  - Stockfish path is auto-detected with an env override (STOCKFISH_PATH).

<!-- End of auto-generated description by cubic. -->

